### PR TITLE
Add an option to ignore EyeFi logs

### DIFF
--- a/etc/eyefiserver.conf
+++ b/etc/eyefiserver.conf
@@ -34,6 +34,10 @@ upload_dir=~/eyefi/%Y/%Y%m%d
 
 use_date_from_file=no
 
+# Should we extract EyeFi logs from image tarfile.
+# They are of little use usually, so default is 'no'.
+
+#extract_logs=yes
 
 # This parameter executes the specified command on each incoming file passing in
 # the full file path as the first argument.

--- a/src/eyefiserver
+++ b/src/eyefiserver
@@ -719,7 +719,14 @@ class EyeFiRequestHandler(BaseHTTPRequestHandler):
 
         eyeFiLogger.debug("Extracting TAR file %s", tarpath)
         imagefilename = imagetarfile.getnames()[0]
-        imagetarfile.extractall(path=upload_dir)
+
+        extract_logs = self.server.config.getboolean(macaddress,
+            'extract_logs', False)
+
+        if extract_logs:
+            imagetarfile.extractall(path=upload_dir)
+        else:
+            imagetarfile.extract(imagefilename, path=upload_dir)
 
         if use_date_from_file and correct_mtime:
             corr_mtime = time.mktime(reference_date.timetuple())


### PR DESCRIPTION
Original request by Alex Volkov at https://bugs.debian.org/756196 :

EyeFi puts its own logs into the tarfiles, which are of little use and just 
litter the upload directory. Proposed patch corrects this behavior.

https://bugs.debian.org/cgi-bin/bugreport.cgi?msg=5;filename=extract_logs.patch;att=1;bug=756196