### PR TITLE
Productionize EyeFiServer: Build process and packaging (rpm)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.pyo
 doc/*.1
 doc/*.5
+*.gz
+*.swp
+*.rpm

--- a/Makefile
+++ b/Makefile
@@ -41,4 +41,7 @@ desktop/eyefiserver-prefs.desktop: desktop/eyefiserver-prefs.desktop.in
 clean:
 	rm -f doc/*.gz systemd/user/eyefiserver.service desktop/eyefiserver-prefs.desktop
 
+gitclean:
+	LANG=C git status | grep -q 'orking directory clean' && { git clean -fxd ; } || { git status ; read -p "Some of these changes will be lost.  Hit ENTER to confirm, Ctrl+C to cancel. " ; git clean -fxd ; }
+
 .PHONY: install clean

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,11 @@ BINDIR=/usr/bin
 MANDIR=/usr/share/man
 SYSCONFDIR=/etc
 INITDDIR=/etc/init.d
+DESKTOPDIR=/usr/share/applications
 USERUNITDIR=/usr/lib/systemd/user
 DESTDIR=
 
-all: doc/eyefiserver.1.gz doc/eyefiserver.conf.5.gz systemd/user/eyefiserver.service
+all: doc/eyefiserver.1.gz doc/eyefiserver.conf.5.gz systemd/user/eyefiserver.service desktop/eyefiserver-prefs.desktop
 
 dist: clean
 	DIR=EyeFiServer-`awk '/^Version:/ {print $$2}' rpm/eyefiserver.spec` && FILENAME=$$DIR.tar.gz && tar cvzf "$$FILENAME" --exclude "$$FILENAME" --exclude .git --exclude .gitignore -X .gitignore --transform=s/^\./$$DIR/ --show-transformed .
@@ -17,6 +18,7 @@ install: all
 	install -Dm 755 src/eyefiserver -t $(DESTDIR)/$(BINDIR)/
 	install -Dm 755 src/eyefiserver-prefs -t $(DESTDIR)/$(BINDIR)/
 	install -Dm 644 etc/eyefiserver.conf -t $(DESTDIR)/$(SYSCONFDIR)/
+	install -Dm 644 desktop/eyefiserver-prefs.desktop -t $(DESTDIR)/$(DESKTOPDIR)/
 	install -Dm 644 systemd/user/eyefiserver.service -t $(DESTDIR)/$(USERUNITDIR)/
 	install -Dm 755 etc/init.d/eyefiserver -t $(DESTDIR)/$(INITDDIR)/
 	install -Dm 644 doc/eyefiserver.1.gz -t $(DESTDIR)/$(MANDIR)/man1/
@@ -33,7 +35,10 @@ doc/eyefiserver.conf.5.gz: doc/eyefiserver.txt
 systemd/user/eyefiserver.service: systemd/user/eyefiserver.service.in
 	sed 's|@BINDIR@|$(BINDIR)|g' < $< > $@
 
+desktop/eyefiserver-prefs.desktop: desktop/eyefiserver-prefs.desktop.in
+	sed 's|@BINDIR@|$(BINDIR)|g' < $< > $@
+
 clean:
-	rm -f doc/*.gz systemd/user/eyefiserver.service
+	rm -f doc/*.gz systemd/user/eyefiserver.service desktop/eyefiserver-prefs.desktop
 
 .PHONY: install clean

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ rpm: dist
 
 install: all
 	install -Dm 755 src/eyefiserver -t $(DESTDIR)/$(BINDIR)/
+	install -Dm 755 src/eyefiserver-prefs -t $(DESTDIR)/$(BINDIR)/
 	install -Dm 644 etc/eyefiserver.conf -t $(DESTDIR)/$(SYSCONFDIR)/
 	install -Dm 644 systemd/user/eyefiserver.service -t $(DESTDIR)/$(USERUNITDIR)/
 	install -Dm 755 etc/init.d/eyefiserver -t $(DESTDIR)/$(INITDDIR)/

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ rpm: dist
 install: all
 	install -Dm 755 src/eyefiserver -t $(DESTDIR)/$(BINDIR)/
 	install -Dm 755 src/eyefiserver-prefs -t $(DESTDIR)/$(BINDIR)/
-	install -Dm 644 etc/eyefiserver.conf -t $(DESTDIR)/$(SYSCONFDIR)/
+	install -Dm 600 etc/eyefiserver.conf -t $(DESTDIR)/$(SYSCONFDIR)/
 	install -Dm 644 desktop/eyefiserver-prefs.desktop -t $(DESTDIR)/$(DESKTOPDIR)/
 	install -Dm 644 systemd/system/eyefiserver.service -t $(DESTDIR)/$(UNITDIR)/
 	install -Dm 644 systemd/user/eyefiserver.service -t $(DESTDIR)/$(USERUNITDIR)/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DESTDIR=
 all: doc/eyefiserver.1.gz doc/eyefiserver.conf.5.gz systemd/user/eyefiserver.service desktop/eyefiserver-prefs.desktop
 
 dist: clean
-	DIR=EyeFiServer-`awk '/^Version:/ {print $$2}' rpm/eyefiserver.spec` && FILENAME=$$DIR.tar.gz && tar cvzf "$$FILENAME" --exclude "$$FILENAME" --exclude .git --exclude .gitignore -X .gitignore --transform=s/^\./$$DIR/ --show-transformed .
+	DIR=EyeFiServer-`awk '/^Version:/ {print $$2}' rpm/eyefiserver.spec` && FILENAME=$$DIR.tar.gz && tar cvzf "$$FILENAME" --exclude "$$FILENAME" --exclude .git --exclude .gitignore -X .gitignore --transform="s|^|$$DIR/|" --show-transformed *
 
 rpm: dist
 	T=`mktemp -d` && rpmbuild --define "_topdir $$T" -ta EyeFiServer-`awk '/^Version:/ {print $$2}' rpm/eyefiserver.spec`.tar.gz || { rm -rf "$$T"; exit 1; } && mv "$$T"/RPMS/noarch/* "$$T"/SRPMS/* . || { rm -rf "$$T"; exit 1; } && rm -rf "$$T"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+BINDIR=/usr/bin
+MANDIR=/usr/share/man
+SYSCONFDIR=/etc
+INITDDIR=/etc/init.d
+USERUNITDIR=/usr/lib/systemd/user
+DESTDIR=
+
+all: doc/eyefiserver.1.gz doc/eyefiserver.conf.5.gz systemd/user/eyefiserver.service
+
+dist: clean
+	DIR=EyeFiServer-`awk '/^Version:/ {print $$2}' rpm/eyefiserver.spec` && FILENAME=$$DIR.tar.gz && tar cvzf "$$FILENAME" --exclude "$$FILENAME" --exclude .git --exclude .gitignore -X .gitignore --transform=s/^\./$$DIR/ --show-transformed .
+
+rpm: dist
+	T=`mktemp -d` && rpmbuild --define "_topdir $$T" -ta EyeFiServer-`awk '/^Version:/ {print $$2}' rpm/eyefiserver.spec`.tar.gz || { rm -rf "$$T"; exit 1; } && mv "$$T"/RPMS/noarch/* "$$T"/SRPMS/* . || { rm -rf "$$T"; exit 1; } && rm -rf "$$T"
+
+install: all
+	install -Dm 755 src/eyefiserver -t $(DESTDIR)/$(BINDIR)/
+	install -Dm 644 etc/eyefiserver.conf -t $(DESTDIR)/$(SYSCONFDIR)/
+	install -Dm 644 systemd/user/eyefiserver.service -t $(DESTDIR)/$(USERUNITDIR)/
+	install -Dm 755 etc/init.d/eyefiserver -t $(DESTDIR)/$(INITDDIR)/
+	install -Dm 644 doc/eyefiserver.1.gz -t $(DESTDIR)/$(MANDIR)/man1/
+	install -Dm 644 doc/eyefiserver.conf.5.gz -t $(DESTDIR)/$(MANDIR)/man5/
+
+doc/eyefiserver.1.gz: doc/eyefiserver.txt
+	txt2man -t eyefiserver -r "eyefiserver" -s 1 -v "Executable programs or shell commands" -I file doc/eyefiserver.txt > doc/eyefiserver.1
+	gzip doc/eyefiserver.1
+
+doc/eyefiserver.conf.5.gz: doc/eyefiserver.txt
+	txt2man -t eyefiserver.conf -r "eyefiserver %{version}" -s 5 -v "File formats and conventions" doc/eyefiserver.conf.txt > doc/eyefiserver.conf.5
+	gzip doc/eyefiserver.conf.5
+
+systemd/user/eyefiserver.service: systemd/user/eyefiserver.service.in
+	sed 's|@BINDIR@|$(BINDIR)|g' < $< > $@
+
+clean:
+	rm -f doc/*.gz systemd/user/eyefiserver.service
+
+.PHONY: install clean

--- a/README
+++ b/README
@@ -1,49 +1,66 @@
-This is eyefiserver version 2.4 +github snapshoot
+This is an improved version of EyeFiServer, a program that receives
+photos from your Eye-Fi card in your camera.
 
-INSTALLATION
-------------
-Structure of this package :
+INSTALLATION OF THE SOFTWARE
+----------------------------
 
-        .
-        |-- etc/
-        |   |-- eyefiserver.conf
-        |   `-- init.d/
-        |       `-- eyefiserver
-        |-- usr/
-            `-- local/
-                |-- bin/
-                |   `-- eyefiserver
-                `-- share/
-                    \-- man/
-                        |-- man1/
-                        |   `-- eyefiserver.1
-                        `-- man5/
-                            `-- eyefiserver.conf.5
+You have two options:
 
-If you're familiar with linux, that basically sums it up :-)
-
-You need to copy the files in the right place.
-
-Optionally add stuff to your start-stop sequence. On debian/ubuntu, use
-update-rc.d:
-    sudo update-rc.d eyefiserver defaults
-
-et voilà.
+* Fedora / Red Hat systems: `make rpm` in the source directory, then
+  install (`rpm -Uvh`) the resulting `noarch` RPM in said directory.
+* Others: `make install`.  See the `Makefile` for control options.
 
 
 CONFIGURATION
 -------------
-To use this script you need to have your Eye-Fi "upload key".
-You can find it after configuring the card, which you can currently on do only
-on Windows or Mac:
+
+You have two options.  You can run the server as part of your regular user
+session (started automatically when you log in), or you can run it every
+time your computer starts.  The first option is what we call a *user session*
+setup, and the second one is a *system wide* setup.
+
+For the user session setup, all you have to do is run *Eye-Fi preferences*
+right from your preferred desktop environment.  If it doesn't appear in the
+menus, then you can run the program `eyefiserver-prefs` and it will let you
+set up your computer to receive photos from your Eye-Fi whenever you are
+logged into your computer.
+
+For the system session setup:
+
+* If you are using the RPM installation (described above), you need to add
+  your upload key to `/etc/eyefiserver.conf`, then enable and restart the
+  `eyefiserver.service` service unit.  You can see the log in real-time
+  using `journalctl -fa`.  Instructions on how to retrieve the upload key
+  from your Windows or Mac OS X system are below.
+* If you are *not* using the RPM installation (that is, you installed using
+  `make` or by manually copying files to their right locations), then
+  you need to set up:
+  * the initscript by hand,
+  * the permissions on the `/etc/eyefiserver.conf` configuration file,
+  * the contents of that file,
+  * the creation of the upload directory, and its permissions.
+
+
+THE INFAMOUS UPLOAD KEY
+-----------------------
+
+To retrieve the upload key, you need to pair your Eye-Fi with the
+Eye-Fi Center (which you can currently on do only
+on Windows or Mac).  Do not enable Relayed Transfer during the
+pairing process.
+
+Once the pairing process is done, you must retrieve the key:
 
 On Windows:
  See C:\Documents and Settings\<User>\Application Data\Eye-Fi\Settings.xml
 On Mac:
  See ~/Applications Data/Eye-Fi/Settings.xml
 
-You must search for it and paste it in eyefiserver.conf. Then server needs to be
-reloaded after editing that file.
+If you are doing a *user session* setup, you can supply the key to the
+preferences program `eyefiserver-prefs`.  If you are doing a *system wide*
+setup, then you must search for `upload_key` in `/etc/eyefiserver.conf`
+and then paste the key there.  Of course, the server needs to be
+restarted after editing that file.
 
 See manual for a full description of options.
 

--- a/desktop/eyefiserver-prefs.desktop.in
+++ b/desktop/eyefiserver-prefs.desktop.in
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Eye-Fi preferences
+Exec=@BINDIR@/eyefiserver-prefs
+Icon=application-x-executable
+Terminal=false
+TryExec=@BINDIR@/eyefiserver-prefs
+Type=Application
+Categories=Settings;X-GNOME-SystemSettings;
+X-AppInstall-Keywords=eyefi

--- a/etc/eyefiserver.conf.in
+++ b/etc/eyefiserver.conf.in
@@ -26,7 +26,7 @@ loglevel=INFO
 #
 # daemon user need write access.
 
-upload_dir=~/eyefi/%Y/%Y%m%d
+upload_dir=@UPLOADDIR@
 
 
 # Do we use the date of the transfer or the date of the file in the camera?

--- a/rpm/eyefiserver.spec
+++ b/rpm/eyefiserver.spec
@@ -10,7 +10,7 @@ License:        GPLv3+
 URL:            https://github.com/nirgal/EyeFiServer
 Source0:	Source0: https://github.com/shiinee/%{name}/archive/{%version}.tar.gz#/%{name}-%{version}.tar.gz
 
-#BuildRequires:  txt2man
+BuildRequires:  txt2man
 BuildArch:	noarch
 Requires:       python2, gobject-introspection, gtk3, pygobject3
 

--- a/rpm/eyefiserver.spec
+++ b/rpm/eyefiserver.spec
@@ -30,7 +30,7 @@ INITDDIR=%{_initddir} MANDIR=%{_mandir} USERUNITDIR=%{_userunitdir}
 rm -rf $RPM_BUILD_ROOT/%{_initddir}/
 
 %files
-%{_bindir}/eyefiserver
+%{_bindir}/eyefiserver*
 %config(noreplace) %{_sysconfdir}/eyefiserver.conf
 %{_userunitdir}/*.service
 %{_mandir}/man?/*.gz

--- a/rpm/eyefiserver.spec
+++ b/rpm/eyefiserver.spec
@@ -1,4 +1,5 @@
 %define debug_package %{nil}
+%define srveyefi /srv/eyefi
 
 Name:           EyeFiServer
 Version:        2.4
@@ -9,7 +10,7 @@ License:        GPLv3+
 URL:            https://github.com/nirgal/EyeFiServer
 Source0:	Source0: https://github.com/shiinee/%{name}/archive/{%version}.tar.gz#/%{name}-%{version}.tar.gz
 
-BuildRequires:  txt2man
+#BuildRequires:  txt2man
 BuildArch:	noarch
 Requires:       python2, gobject-introspection, gtk3, pygobject3
 
@@ -21,22 +22,72 @@ brand wireless SD devices.
 %setup -q
 
 %build
-make
+# variables must be kept in sync with install
+make DESTDIR=$RPM_BUILD_ROOT BINDIR=%{_bindir} SYSCONFDIR=%{_sysconfdir} \
+INITDDIR=%{_initddir} MANDIR=%{_mandir} USERUNITDIR=%{_userunitdir} \
+DESKTOPDIR=%{_datadir}/applications \
+UNITDIR=%{_unitdir} \
+UPLOADDIR=%srveyefi \
 
 %install
 rm -rf $RPM_BUILD_ROOT
+# variables must be kept in sync with build
 make install DESTDIR=$RPM_BUILD_ROOT BINDIR=%{_bindir} SYSCONFDIR=%{_sysconfdir} \
 INITDDIR=%{_initddir} MANDIR=%{_mandir} USERUNITDIR=%{_userunitdir} \
 DESKTOPDIR=%{_datadir}/applications \
+UNITDIR=%{_unitdir} \
+UPLOADDIR=%srveyefi \
+
+mkdir -p $RPM_BUILD_ROOT%srveyefi
 
 rm -rf $RPM_BUILD_ROOT/%{_initddir}/
 
+%pre
+if [ $1 -eq 1 ] ; then
+  # Create eyefi gid as long as it does not already exist
+  cat /etc/group | cut -d':' -f 1 | grep --quiet '^eyefi$' 2>/dev/null
+  if [ "$?" -eq 1 ]; then
+    # Initial installation
+    /usr/sbin/groupadd -r eyefi >/dev/null 2>&1 || :
+  fi
+
+  # Create eyefi uid as long as it does not already exist.
+  cat /etc/passwd | cut -d':' -f 1 | grep --quiet '^eyefi$' 2>/dev/null
+  if [ "$?" -eq 1 ]; then
+    # Initial installation
+    /usr/sbin/useradd -l -c "Eye-Fi server user" -r -g eyefi \
+        -s /sbin/nologin -r -d %srveyefi eyefi >/dev/null 2>&1 || :
+  fi
+fi
+
+%post
+if [ $1 -eq 1 ] ; then
+    # Initial installation
+    systemctl preset eyefiserver >/dev/null 2>&1 || :
+fi
+
+%preun
+if [ $1 -eq 0 ] ; then
+        # Package removal, not upgrade
+        systemctl --no-reload disable eyefiserver.service > /dev/null 2>&1 || :
+        systemctl stop eyefiserver.service > /dev/null 2>&1 || :
+fi
+
+%postun
+systemctl daemon-reload >/dev/null 2>&1 || :
+if [ $1 -ge 1 ] ; then
+        # Package upgrade, not uninstall
+        systemctl try-restart eyefiserver.service >/dev/null 2>&1 || :
+fi
+
 %files
 %{_bindir}/eyefiserver*
-%config(noreplace) %{_sysconfdir}/eyefiserver.conf
+%attr(400, eyefi, root) %config(noreplace) %{_sysconfdir}/eyefiserver.conf
 %{_userunitdir}/*.service
+%{_unitdir}/*.service
 %{_datadir}/applications/*.desktop
 %{_mandir}/man?/*.gz
+%attr(2770, eyefi, eyefi) %verify() %srveyefi
 
 %doc doc/* LICENSE README changelog
 

--- a/rpm/eyefiserver.spec
+++ b/rpm/eyefiserver.spec
@@ -26,13 +26,16 @@ make
 %install
 rm -rf $RPM_BUILD_ROOT
 make install DESTDIR=$RPM_BUILD_ROOT BINDIR=%{_bindir} SYSCONFDIR=%{_sysconfdir} \
-INITDDIR=%{_initddir} MANDIR=%{_mandir} USERUNITDIR=%{_userunitdir}
+INITDDIR=%{_initddir} MANDIR=%{_mandir} USERUNITDIR=%{_userunitdir} \
+DESKTOPDIR=%{_datadir}/applications \
+
 rm -rf $RPM_BUILD_ROOT/%{_initddir}/
 
 %files
 %{_bindir}/eyefiserver*
 %config(noreplace) %{_sysconfdir}/eyefiserver.conf
 %{_userunitdir}/*.service
+%{_datadir}/applications/*.desktop
 %{_mandir}/man?/*.gz
 
 %doc doc/* LICENSE README changelog

--- a/rpm/eyefiserver.spec
+++ b/rpm/eyefiserver.spec
@@ -11,7 +11,7 @@ Source0:	Source0: https://github.com/shiinee/%{name}/archive/{%version}.tar.gz#/
 
 BuildRequires:  txt2man
 BuildArch:	noarch
-Requires:       python2
+Requires:       python2, gobject-introspection, gtk3, pygobject3
 
 %description
 eyefiserver is a daemon that accepts connections and receives files from Eye-Fi

--- a/rpm/eyefiserver.spec
+++ b/rpm/eyefiserver.spec
@@ -1,0 +1,42 @@
+%define debug_package %{nil}
+
+Name:           EyeFiServer
+Version:        2.4
+Release:        1%{?dist}
+Summary:        An open source Eye-Fi server
+
+License:        GPLv3+
+URL:            https://github.com/nirgal/EyeFiServer
+Source0:	Source0: https://github.com/shiinee/%{name}/archive/{%version}.tar.gz#/%{name}-%{version}.tar.gz
+
+BuildRequires:  txt2man
+BuildArch:	noarch
+Requires:       python2
+
+%description
+eyefiserver is a daemon that accepts connections and receives files from Eye-Fi
+brand wireless SD devices.
+
+%prep
+%setup -q
+
+%build
+make
+
+%install
+rm -rf $RPM_BUILD_ROOT
+make install DESTDIR=$RPM_BUILD_ROOT BINDIR=%{_bindir} SYSCONFDIR=%{_sysconfdir} \
+INITDDIR=%{_initddir} MANDIR=%{_mandir} USERUNITDIR=%{_userunitdir}
+rm -rf $RPM_BUILD_ROOT/%{_initddir}/
+
+%files
+%{_bindir}/eyefiserver
+%config(noreplace) %{_sysconfdir}/eyefiserver.conf
+%{_userunitdir}/*.service
+%{_mandir}/man?/*.gz
+
+%doc doc/* LICENSE README changelog
+
+%changelog
+* Mon Feb  8 2016 Skyler Leigh Amador
+- Packaging the most current release of eyefiserver from github

--- a/src/eyefiserver
+++ b/src/eyefiserver
@@ -796,6 +796,21 @@ class EyeFiConfig(RawConfigParser):
     """
     Helper wraper around ConfigParser.RawConfigParser
     Provides get() method with fallback to a global section and default values
+
+    All configuration settings can be keyed to the MAC address of the
+    Eye-Fi device (as a section of the INI file), and if the section
+    does not exist, then the section 'EyeFiServer' is consulted for
+    the configuration values.  If that fals, then most config values
+    default to sensible defaults.
+
+    List of config settings:
+      config.getuploaddir                       defaults to ~/eyefi
+      config.get upload_key                     mandatory
+      config.get progress_execute               defaults to nothing
+      config.get complete_execute               defaults to nothing
+      config.getboolean correct_mtime           defaults to True
+      config.getboolean use_date_from_file      defaults to False
+      config.getboolean integrity_verification  defaults to True
     """
     def __init__(self, conffiles):
         RawConfigParser.__init__(self)

--- a/src/eyefiserver
+++ b/src/eyefiserver
@@ -884,13 +884,15 @@ def main():
         action='append', dest='conffiles',
         help='specific alternate location for configuration file. '
              'default=%(default)s',
-        default=['/etc/eyefiserver.conf',
-                 os.path.expanduser('~/eyefiserver.conf')])
+        default=[])
     parser.add_argument(
         '--log', metavar='LOGFILE',
         dest='logfile',
         help='log to file')
     options = parser.parse_args()
+    if not options.conffiles:
+        options.conffiles = ['/etc/eyefiserver.conf',
+                             os.path.expanduser('~/eyefiserver.conf')]
 
     # Create two handlers. One to print to the log and one to print to the
     # console

--- a/src/eyefiserver-prefs
+++ b/src/eyefiserver-prefs
@@ -1,0 +1,312 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+#
+# This is the user service configurator of EyeFiServer.
+#
+#  Copyright (c) 2016 Skyler Leigh
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import ConfigParser
+import contextlib
+import functools
+import gi ; gi.require_version("Gtk", "3.0")
+from gi.repository import GObject, Gtk, Pango
+import os
+import subprocess
+import sys
+
+
+def get_documents_dir():
+    try:
+        d = subprocess.check_output(["xdg-user-dir", "DOCUMENTS"]).rstrip("\n")
+    except Exception:
+        d = os.path.expanduser("~/Documents")
+    return d
+
+
+def systemd_service_enabled(svc):
+    try:
+        d = subprocess.check_output(["systemctl", "--user",
+                                    "is-enabled", svc])
+        return True
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 1:
+            return False
+        raise
+
+
+def systemd_action(action, svc):
+    subprocess.check_output(["systemctl", "--user",
+                           action, svc], stderr=subprocess.STDOUT)
+
+
+systemd_disable_service = functools.partial(systemd_action, "disable")
+systemd_enable_service = functools.partial(systemd_action, "enable")
+systemd_stop_service = functools.partial(systemd_action, "stop")
+systemd_restart_service = functools.partial(systemd_action, "restart")
+systemd_start_service = functools.partial(systemd_action, "start")
+
+
+def create_dirs(path):
+    dirs = []
+    last_path = None
+    while last_path != path:
+        head, tail = os.path.split(path)
+        dirs.append(path)
+        last_path = path
+        path = head
+    dirs.reverse()
+    created_dirs = []
+    for d in dirs:
+        if not os.path.isdir(d):
+            try:
+                os.mkdir(d)
+                created_dirs.append(d)
+            except (IOError, OSError):
+                break
+    created_dirs.reverse()
+    return created_dirs
+
+
+def remove_dirs(dirlist):
+    for d in dirlist:
+        try:
+            os.rmdir(d)
+        except (IOError, OSError):
+            break
+
+
+@contextlib.contextmanager
+def phantom_directory(directory):
+    created_dirs = create_dirs(directory)
+    try:
+        yield directory
+    finally:
+        remove_dirs(created_dirs)
+
+
+def FatalError(message, secondary=None, outside_mainloop=False, parent=None):
+    d = Gtk.MessageDialog(
+        parent,
+        Gtk.DialogFlags.DESTROY_WITH_PARENT,
+        Gtk.MessageType.ERROR,
+        Gtk.ButtonsType.CLOSE,
+        message,
+    )
+    if secondary:
+        d.format_secondary_text(secondary)
+    d.run()
+
+
+class EyeFiServerPrefsWindow(Gtk.Window):
+
+    returncode = 0
+
+    def __init__(self, config_expert):
+        self.config_expert = config_expert
+        Gtk.Window.__init__(self, title="Eye-Fi server preferences")
+        self.set_border_width(12)
+        self.set_default_size(400,-1)
+
+        grid = Gtk.Grid()
+        grid.set_column_spacing(8)
+        grid.set_row_spacing(8)
+        self.add(grid)
+
+        self.enable = Gtk.CheckButton("Fetch photos from Eye-Fi card")
+        grid.attach(self.enable, 0, 0, 1, 1)
+        self.connect("delete-event", self.exit_requested)
+
+        subgrid = Gtk.Grid()
+        self.enable.connect("toggled", lambda *_: subgrid.set_sensitive(self.enable.get_active()))
+        self.enable.connect("toggled", self.calculate_validation)
+        subgrid.set_sensitive(self.enable.get_active())
+        subgrid.set_column_spacing(8)
+        subgrid.set_row_spacing(12)
+        subgrid.set_margin_left(12)
+        subgrid.set_vexpand(True)
+        grid.attach(subgrid, 0, 1, 1, 1)
+
+        label = Gtk.Label()
+        label.set_markup("<i>Obtain the required upload key from your Windows or Mac OS X Eye-Fi center configuration.</i>")
+        label.set_line_wrap(True)
+        label.set_line_wrap_mode(Pango.WrapMode.WORD_CHAR)
+        label.set_xalign(0.0)
+        subgrid.attach(label, 0, 0, 2, 1)
+
+        label = Gtk.Label("Use upload key")
+        label.set_xalign(0.0)
+        subgrid.attach(label, 0, 1, 1, 1)
+        self.upload_key = Gtk.Entry()
+        self.upload_key.connect("changed", self.calculate_validation)
+        self.upload_key.set_hexpand(True)
+        subgrid.attach(self.upload_key, 1, 1, 1, 1)
+
+        label = Gtk.Label("Save photos in")
+        label.set_xalign(0.0)
+        subgrid.attach(label, 0, 2, 1, 1)
+        self.download_folder = Gtk.FileChooserButton()
+        self.download_folder.connect("file-set", self.calculate_validation)
+        self.download_folder.set_title("Select Eye-Fi download folder")
+        self.download_folder.set_action(Gtk.FileChooserAction.SELECT_FOLDER)
+        self.download_folder.set_hexpand(True)
+        subgrid.attach(self.download_folder, 1, 2, 1, 1)
+
+        button_box = Gtk.ButtonBox()
+        grid.attach(button_box, 0, 2, 1, 1)
+        button_box.set_layout(Gtk.ButtonBoxStyle.END)
+        button_box.set_spacing(12)
+        button_box.set_hexpand(True)
+        self.cancel_button = Gtk.Button(stock=Gtk.STOCK_CANCEL)
+        button_box.add(self.cancel_button)
+        self.cancel_button.connect("clicked", self.exit_requested)
+        self.apply_button = Gtk.Button(stock=Gtk.STOCK_APPLY)
+        button_box.add(self.apply_button)
+        self.apply_button.set_can_default(True)
+        self.apply_button.grab_default()
+        self.apply_button.connect("clicked", self.apply_)
+        GObject.idle_add(self.load_)
+
+    def get_download_folder(self):
+        filename = self.download_folder.get_filename()
+        return filename if filename else None
+
+    def get_upload_key(self):
+        text = self.upload_key.get_text().strip()
+        return text if text else None
+
+    def get_enabled(self):
+        return self.enable.get_active()
+
+    def calculate_validation(self, *unused_args):
+        if (
+            (self.get_upload_key() and self.get_download_folder()) or
+            not self.get_enabled()
+        ):
+            self.apply_button.set_sensitive(True)
+        else:
+            self.apply_button.set_sensitive(False)
+
+    def load_(self):
+        enabled, upload_key, download_folder = self.config_expert.load_settings()
+        self.enable.set_active(enabled)
+        self.upload_key.set_text('' if upload_key is None else upload_key)
+        if download_folder:
+            with phantom_directory(download_folder):
+                self.download_folder.set_filename(download_folder)
+        self.calculate_validation()
+
+    def apply_(self, *ignored_args):
+        try:
+            self.config_expert.save_and_activate_settings(
+                self.get_enabled(),
+                self.get_upload_key(),
+                self.get_download_folder(),
+            )
+        except subprocess.CalledProcessError as e:
+            FatalError(
+                "Cannot apply settings",
+                "An error took place applying the state of the Eye-Fi service: %s" % e.output,
+                parent=self,
+            )
+            self.returncode = e.returncode
+        self.exit_requested()
+
+    def exit_requested(self, *ignored_args):
+        Gtk.main_quit()
+
+
+class EyeFiConfigExpert(ConfigParser.RawConfigParser):
+
+    config_file = os.path.expanduser("~/.config/eyefiserver.conf")
+    service = "eyefiserver.service"
+
+    def set_or_del(self, section, option, value):
+        if value is not None:
+            return self.set(section, option, value)
+        if self.has_option(section, option):
+            return self.remove_option(section, option)
+
+    def get_or_default(self, section, option, default=None):
+        if self.has_option(section, option):
+            return self.get(section, option)
+        return default
+
+    def get_or_none(self, section, option):
+        return self.get_or_default(section, option)
+
+    def load_defaults(self):
+        return None, os.path.join(get_documents_dir(), "Eye-Fi")
+
+    def load_settings(self):
+        upload_key, download_folder = self.load_defaults()
+
+        sec = "EyeFiServer"
+        self.read([self.config_file])
+
+        if not self.has_section(sec):
+            self.add_section(sec)
+
+        upload_key = self.get_or_default(sec, "upload_key", upload_key)
+        download_folder = self.get_or_default(sec, "upload_dir", download_folder)
+
+        enabled = systemd_service_enabled("eyefiserver.service")
+
+        return enabled, upload_key, download_folder
+
+    def save_and_activate_settings(self,
+                                   new_enabled,
+                                   new_upload_key,
+                                   new_download_folder):
+        sec = "EyeFiServer"
+
+        upload_key = self.get_or_none(sec, "upload_key")
+        download_folder = self.get_or_none(sec, "upload_dir")
+        enabled = systemd_service_enabled(self.service)
+
+        changed = False
+        if upload_key != new_upload_key:
+            changed = True
+            self.set_or_del(sec, "upload_key", new_upload_key)
+        if download_folder != new_download_folder:
+            changed = True
+            self.set_or_del(sec, "upload_dir", new_download_folder)
+
+        if changed:
+            old_umask = os.umask(0077)
+            try:
+                cfg = open(self.config_file, "wb")
+                self.write(cfg)
+                cfg.flush()
+                cfg.close()
+            finally:
+                os.umask(old_umask)
+
+        if new_enabled:
+            systemd_enable_service(self.service)
+            if changed or new_enabled != enabled:
+                systemd_restart_service(self.service)
+        else:
+            systemd_stop_service(self.service)
+            systemd_disable_service(self.service)
+
+
+def main():
+    config_expert = EyeFiConfigExpert()
+    app = EyeFiServerPrefsWindow(config_expert)
+    GObject.idle_add(app.show_all)
+    Gtk.main()
+    return app.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/eyefiserver-prefs
+++ b/src/eyefiserver-prefs
@@ -25,6 +25,9 @@ import subprocess
 import sys
 
 
+DEFAULT_PORT = 59278
+
+
 def get_documents_dir():
     try:
         d = subprocess.check_output(["xdg-user-dir", "PICTURES"]).rstrip("\n")
@@ -33,13 +36,17 @@ def get_documents_dir():
     return d
 
 
+def systemd_daemon_reload():
+    d = subprocess.check_output(["systemctl", "--user", "daemon-reload"])
+
+
 def systemd_boolean_query(query, svc):
     try:
         d = subprocess.check_output(["systemctl", "--user",
                                      query, svc])
         return True
     except subprocess.CalledProcessError as e:
-        if e.returncode == 1:
+        if e.returncode in (1, 3):
             return False
         raise
 
@@ -53,8 +60,8 @@ def systemd_action(action, svc):
                            action, svc], stderr=subprocess.STDOUT)
 
 
-systemd_disable_service = functools.partial(systemd_action, "disable")
 systemd_enable_service = functools.partial(systemd_action, "enable")
+systemd_disable_service = functools.partial(systemd_action, "disable")
 systemd_stop_service = functools.partial(systemd_action, "stop")
 systemd_restart_service = functools.partial(systemd_action, "restart")
 systemd_start_service = functools.partial(systemd_action, "start")
@@ -119,14 +126,13 @@ class EyeFiServerPrefsWindow(Gtk.Window):
         self.config_expert = config_expert
         Gtk.Window.__init__(self, title="Eye-Fi server preferences")
         self.set_border_width(12)
-        self.set_default_size(400,-1)
 
         grid = Gtk.Grid()
         grid.set_column_spacing(8)
         grid.set_row_spacing(8)
         self.add(grid)
 
-        self.enable = Gtk.CheckButton("Fetch photos from Eye-Fi card")
+        self.enable = Gtk.CheckButton("Receive photos from Eye-Fi card")
         grid.attach(self.enable, 0, 0, 1, 1)
         self.connect("delete-event", self.exit_requested)
 
@@ -140,12 +146,21 @@ class EyeFiServerPrefsWindow(Gtk.Window):
         subgrid.set_vexpand(True)
         grid.attach(subgrid, 0, 1, 1, 1)
 
-        label = Gtk.Label()
-        label.set_markup("<i>Obtain the required upload key from your Windows or Mac OS X Eye-Fi center configuration.</i>")
-        label.set_line_wrap(True)
-        label.set_line_wrap_mode(Pango.WrapMode.WORD_CHAR)
-        label.set_xalign(0.0)
-        subgrid.attach(label, 0, 0, 2, 1)
+        strings = [
+            ("• Pair your Eye-Fi card with your (Windows"
+             " or Mac OS X) Eye-Fi Center."),
+            "• Ensure you disable Relayed Transfer as you pair your Eye-Fi card.",
+            "• Then transfer the upload key here from the Eye-Fi settings file:",
+            "   • Windows: <i>C:\\Users\\&lt;user&gt;\\Application Data\\Eye-Fi\\Settings.xml</i>",
+            "   • Mac OS X: <i>~/Applications Data/Eye-Fi/Settings.xml</i>",
+        ]
+        vbox = Gtk.VBox()
+        for string in strings:
+            label = Gtk.Label()
+            label.set_markup(string)
+            label.set_xalign(0.0)
+            vbox.add(label)
+        subgrid.attach(vbox, 0, 0, 2, 1)
 
         label = Gtk.Label("Use upload key")
         label.set_xalign(0.0)
@@ -155,7 +170,7 @@ class EyeFiServerPrefsWindow(Gtk.Window):
         self.upload_key.set_hexpand(True)
         subgrid.attach(self.upload_key, 1, 1, 1, 1)
 
-        label = Gtk.Label("Save photos in")
+        label = Gtk.Label("Save photos to")
         label.set_xalign(0.0)
         subgrid.attach(label, 0, 2, 1, 1)
         self.download_folder = Gtk.FileChooserButton()
@@ -164,6 +179,18 @@ class EyeFiServerPrefsWindow(Gtk.Window):
         self.download_folder.set_action(Gtk.FileChooserAction.SELECT_FOLDER)
         self.download_folder.set_hexpand(True)
         subgrid.attach(self.download_folder, 1, 2, 1, 1)
+
+        label = Gtk.Label()
+        label.set_markup(
+            "If your computer has a firewall, now is a good time to open"
+            " TCP port %s in your firewall setup.  Eye-Fi will send your"
+            " photos to that port." % DEFAULT_PORT
+        )
+        label.set_line_wrap(True)
+        label.set_line_wrap_mode(Pango.WrapMode.WORD_CHAR)
+        label.set_xalign(0.0)
+        label.do_get_preferred_width = lambda: (100, 100)
+        subgrid.attach(label, 0, 3, 2, 1)
 
         button_box = Gtk.ButtonBox()
         grid.attach(button_box, 0, 2, 1, 1)
@@ -179,6 +206,8 @@ class EyeFiServerPrefsWindow(Gtk.Window):
         self.apply_button.grab_default()
         self.apply_button.connect("clicked", self.apply_)
         GObject.idle_add(self.load_)
+
+        self.set_default_size(520, -1)
 
     def get_download_folder(self):
         filename = self.download_folder.get_filename()
@@ -275,6 +304,7 @@ class EyeFiConfigExpert(ConfigParser.RawConfigParser):
 
         upload_key = self.get_or_none(sec, "upload_key")
         download_folder = self.get_or_none(sec, "upload_dir")
+        systemd_daemon_reload()
         enabled = systemd_service_enabled(self.service)
         running = systemd_service_running(self.service)
 

--- a/src/eyefiserver-prefs
+++ b/src/eyefiserver-prefs
@@ -33,15 +33,19 @@ def get_documents_dir():
     return d
 
 
-def systemd_service_enabled(svc):
+def systemd_boolean_query(query, svc):
     try:
         d = subprocess.check_output(["systemctl", "--user",
-                                    "is-enabled", svc])
+                                     query, svc])
         return True
     except subprocess.CalledProcessError as e:
         if e.returncode == 1:
             return False
         raise
+
+
+systemd_service_enabled = functools.partial(systemd_boolean_query, "is-enabled")
+systemd_service_running = functools.partial(systemd_boolean_query, "is-active")
 
 
 def systemd_action(action, svc):
@@ -272,6 +276,7 @@ class EyeFiConfigExpert(ConfigParser.RawConfigParser):
         upload_key = self.get_or_none(sec, "upload_key")
         download_folder = self.get_or_none(sec, "upload_dir")
         enabled = systemd_service_enabled(self.service)
+        running = systemd_service_running(self.service)
 
         changed = False
         if upload_key != new_upload_key:
@@ -293,7 +298,7 @@ class EyeFiConfigExpert(ConfigParser.RawConfigParser):
 
         if new_enabled:
             systemd_enable_service(self.service)
-            if changed or new_enabled != enabled:
+            if changed or new_enabled != enabled or not running:
                 systemd_restart_service(self.service)
         else:
             systemd_stop_service(self.service)

--- a/src/eyefiserver-prefs
+++ b/src/eyefiserver-prefs
@@ -27,9 +27,9 @@ import sys
 
 def get_documents_dir():
     try:
-        d = subprocess.check_output(["xdg-user-dir", "DOCUMENTS"]).rstrip("\n")
+        d = subprocess.check_output(["xdg-user-dir", "PICTURES"]).rstrip("\n")
     except Exception:
-        d = os.path.expanduser("~/Documents")
+        d = os.path.expanduser("~/Pictures")
     return d
 
 

--- a/systemd/system/eyefiserver.service.in
+++ b/systemd/system/eyefiserver.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=EyeFi Server
+Documentation=man:eyefiserver.conf(5)
+
+[Service]
+Type=simple
+User=eyefi
+ExecStart=@BINDIR@/eyefiserver --conf=@SYSCONFDIR@/eyefiserver.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/user/eyefiserver.service.in
+++ b/systemd/user/eyefiserver.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=EyeFi Server
+Documentation=man:eyefiserver.conf(5)
+
+[Service]
+Type=simple
+ExecStart=@BINDIR@/eyefiserver --conf=%h/.config/eyefiserver.conf
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
I put together a pretty simple build and package for the EyeFi server so it's easier to install. 

Since I use Fedora, I wrote an rpm spec, and also added unit file for systemd since fedora doesn't use init anymore. I imagine you must be on a Debian based distro due to the init script :) If I can figure out how, I can also make a deb package for it.

My collaborator, @Rudd-O, made a nice little gui configurator that edits the user settings.

There are a few other changes in here that I needed in order to run properly on my machine. There was a small bug in the --conf option, where it would read /etc/eyefiserver.conf and ~/eyefiserver.conf in addition to what the user passes in. 

It's up to you whether you want to accept these additions, but I think they make things easier :)
